### PR TITLE
Added -y command line option to move characters up in their cells, to…

### DIFF
--- a/src/main/java/com/arcao/fontcreator/ArgumentParser.java
+++ b/src/main/java/com/arcao/fontcreator/ArgumentParser.java
@@ -20,10 +20,12 @@ public class ArgumentParser {
     private final OptionSpec<String> charset;
     private final OptionSpec<File> outputFile;
     private final OptionSpec<String> font;
+    private final OptionSpec<Integer> yoffset;
 
     public ArgumentParser() {
         help = parser.acceptsAll(asList("h", "help"), "display this help and exit").forHelp();
         size = parser.acceptsAll(asList("s", "size"), "font size").withRequiredArg().ofType(Integer.class);
+        yoffset = parser.acceptsAll(asList("y", "yoffset"), "shifts characters upwards (pixels)").withOptionalArg().ofType(Integer.class).defaultsTo(0);
         bold = parser.acceptsAll(asList("b", "bold"), "use bold font variant");
         italic = parser.acceptsAll(asList("i", "italic"), "use italic font style");
         charset = parser.acceptsAll(asList("c", "charset"), "font table index charset").withOptionalArg().defaultsTo("iso-8859-1").ofType(String.class);
@@ -45,6 +47,11 @@ public class ArgumentParser {
                 return options.valueOf(size);
             }
 
+            @Override
+            public int yoffset() {
+                return options.valueOf(yoffset);
+            }
+			
             @Override
             public boolean bold() {
                 return options.has(bold);

--- a/src/main/java/com/arcao/fontcreator/Arguments.java
+++ b/src/main/java/com/arcao/fontcreator/Arguments.java
@@ -17,4 +17,7 @@ interface Arguments {
     File outputFile();
 
     String font();
+	
+    int yoffset();
+	
 }

--- a/src/main/java/com/arcao/fontcreator/FontConverterV3.java
+++ b/src/main/java/com/arcao/fontcreator/FontConverterV3.java
@@ -26,6 +26,8 @@ public class FontConverterV3 {
     private FontMetrics fontMetrics;
     private BufferedImage image;
     private Charset charset;
+	
+	private int yoffset;
 
 
     public FontConverterV3(Font font) {
@@ -42,7 +44,8 @@ public class FontConverterV3 {
         this.charset = charset;
     }
 
-    public void printFontData(StringBuilder builder) {
+    public void printFontData(StringBuilder builder, int yoffset) {
+		this.yoffset=yoffset;
         List<LetterData> letterList = produceLetterDataList();
 
         String fontName = g.getFont().getFontName().replaceAll("[\\s\\-\\.]", "_") + "_"
@@ -112,7 +115,7 @@ public class FontConverterV3 {
 
         int character[] = new int[arraySize];
 
-        boolean isVisableChar = false;
+        boolean isVisibleChar = false;
 
         if (width > 0) {
             for (int i = 0; i < arraySize; i++) {
@@ -122,7 +125,7 @@ public class FontConverterV3 {
                 for (int b = 0; b < 8; b++) {
                     if (yImg + b <= height) {
                         if (letterImage.getRGB(xImg, yImg + b) == Color.BLACK.getRGB()) {
-                            isVisableChar = true;
+                            isVisibleChar = true;
                             currentByte = currentByte | (1 << b);
                         } else {
                             currentByte = currentByte & ~(1 << b);
@@ -143,14 +146,14 @@ public class FontConverterV3 {
 
         character = Arrays.copyOf(character, lastByteNotNull + 1);
 
-        return new LetterData(code, character, width, isVisableChar);
+        return new LetterData(code, character, width, isVisibleChar);
     }
 
     private BufferedImage drawLetter(char code) {
         g.setColor(Color.WHITE);
         g.fillRect(0, 0, 450, 250);
         g.setColor(Color.BLACK);
-        g.drawString(String.valueOf(code), 0, fontMetrics.getAscent() + fontMetrics.getLeading());
+        g.drawString(String.valueOf(code), 0, fontMetrics.getAscent() + fontMetrics.getLeading() - yoffset);
         return image;
     }
 

--- a/src/main/java/com/arcao/fontcreator/FontCreator.java
+++ b/src/main/java/com/arcao/fontcreator/FontCreator.java
@@ -63,7 +63,7 @@ public class FontCreator {
             FontConverterV3 fontConverter = new FontConverterV3(font, charset);
 
             StringBuilder builder = new StringBuilder();
-            fontConverter.printFontData(builder);
+            fontConverter.printFontData(builder,arguments.yoffset());
 
             PrintStream out = System.out;
             if (arguments.outputFile() != null) {

--- a/src/main/java/com/arcao/fontcreator/FontCreator.java
+++ b/src/main/java/com/arcao/fontcreator/FontCreator.java
@@ -63,7 +63,7 @@ public class FontCreator {
             FontConverterV3 fontConverter = new FontConverterV3(font, charset);
 
             StringBuilder builder = new StringBuilder();
-            fontConverter.printFontData(builder,arguments.yoffset());
+            fontConverter.printFontData(builder, arguments.yoffset());
 
             PrintStream out = System.out;
             if (arguments.outputFile() != null) {


### PR DESCRIPTION
… allow reduction of whitespace and more efficient use of space on small OLEDs.

Space is scarce and valuable on a 128x64 (not to mention 128x32) OLED display. Fonts created by this tool, and the http://oleddisplay.squix.ch tool it was based on, leave at least one row of pixels blank. The SSD1306 library code does not allow drawing text starting at Y location -1.

So, the easiest way to achieve efficient use of space seemed to be modify the font creator itself, hence this pull request.

I also changed a misspelled variable name in a function, while I was in there.